### PR TITLE
Track app launch status

### DIFF
--- a/apps/launcher-rust/src-tauri/src/lib.rs
+++ b/apps/launcher-rust/src-tauri/src/lib.rs
@@ -356,8 +356,8 @@ async fn launch_app(
     app_data_path: State<'_, states::DataDirPath>,
     apps_running: State<'_, Mutex<states::AppsRunningStatus>>,
 ) -> Result<u32, String> {
-    let app_data_path = &app_data_path.inner().0;
-    let app_json_path = app_data_path.join(format!("apps/{}.json", app_id));
+    let data_dir_path = &app_data_path.inner().0;
+    let app_json_path = data_dir_path.join(format!("apps/{}.json", app_id));
 
     let file =
         File::open(app_json_path).map_err(|e| format!("Failed to open app json file: {}", e))?;

--- a/apps/launcher-rust/src-tauri/src/lib.rs
+++ b/apps/launcher-rust/src-tauri/src/lib.rs
@@ -5,8 +5,10 @@ use std::collections::{HashMap, VecDeque};
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 use tar::{Archive, Builder};
+use tauri::async_runtime::spawn;
 use tauri::State;
 use tauri::{
     menu::{Menu, MenuItem},
@@ -16,12 +18,14 @@ use tauri::{
 use tokio::process::Command;
 use tokio::sync::Mutex;
 
+use crate::process_monitor::{ProcessEvent, ProcessMonitor};
 use crate::rate_meter::RateMeter;
 use crate::tracking_reader::TrackingReader;
 use crate::tracking_tokio_stream::TrackingTokioStream;
 use crate::tracking_writer::TrackingWriter;
 
 mod models;
+mod process_monitor;
 mod rate_meter;
 mod states;
 mod tracking_reader;
@@ -354,7 +358,8 @@ async fn upload_file_as_form_data(
 async fn launch_app(
     app_id: String,
     app_data_path: State<'_, states::DataDirPath>,
-    apps_running: State<'_, Mutex<states::AppsRunningStatus>>,
+    app_pid_map: State<'_, states::AppPidMap>,
+    proc_mon: State<'_, states::ProcessMonitorInstance>,
 ) -> Result<u32, String> {
     let data_dir_path = &app_data_path.inner().0;
     let app_json_path = data_dir_path.join(format!("apps/{}.json", app_id));
@@ -373,37 +378,72 @@ async fn launch_app(
     let app_child = Command::new(entrypoint_path)
         .spawn()
         .map_err(|e| format!("Failed to spawn app process: {}", e))?;
-    let pid = app_child.id().ok_or_else(|| format!("Child not started"))?;
+    let pid = app_child
+        .id()
+        .ok_or_else(|| "Child not started".to_string())?;
 
-    apps_running
-        .lock()
-        .await
-        .app2child
-        .insert(app_id, app_child);
-
-    // TODO: wait for child close and remove it from apps_running.app2child map
+    let mut app_pid_map = app_pid_map.lock().await;
+    app_pid_map.appid2pid.insert(app_id.clone(), pid);
+    app_pid_map.pid2appid.insert(pid, app_id.clone());
+    proc_mon.lock().await.add(app_child).await;
 
     Ok(pid)
 }
 
 #[tauri::command]
+async fn is_app_running(
+    app_id: String,
+    app_pid_map: State<'_, states::AppPidMap>,
+) -> Result<bool, String> {
+    Ok(app_pid_map.lock().await.appid2pid.contains_key(&app_id))
+}
+
+#[tauri::command]
 async fn wait_for_app_close(
     app_id: String,
-    apps_running: State<'_, Mutex<states::AppsRunningStatus>>,
+    app_pid_map: State<'_, states::AppPidMap>,
+    proc_mon_rx: State<'_, states::ProcessMonitorReceiver>,
 ) -> Result<(), String> {
-    let mut apps_running = apps_running.lock().await;
-    let child = if let Some(v) = apps_running.app2child.get_mut(&app_id) {
-        v
-    } else {
-        return Ok(());
+    let pid = {
+        if let Some(v) = app_pid_map.lock().await.appid2pid.get(&app_id) {
+            *v
+        } else {
+            return Err("Process not running".to_string());
+        }
     };
 
-    child
-        .wait()
-        .await
-        .map_err(|e| format!("Failed to wait for child process: {}", e))?;
+    let mut rx = { proc_mon_rx.lock().await.resubscribe() };
+    while let Ok(ev) = rx.recv().await {
+        match ev {
+            ProcessEvent::Terminated(terminated_pid) => {
+                if terminated_pid == pid {
+                    break;
+                }
+            }
+        }
+    }
 
     Ok(())
+}
+
+#[tauri::command]
+async fn terminate_app(
+    app_id: String,
+    app_pid_map: State<'_, states::AppPidMap>,
+    proc_mon: State<'_, states::ProcessMonitorInstance>,
+) -> Result<(), String> {
+    let pid = if let Some(v) = app_pid_map.lock().await.appid2pid.get(&app_id) {
+        *v
+    } else {
+        return Err("Application not running".to_string());
+    };
+
+    proc_mon
+        .lock()
+        .await
+        .terminate(pid)
+        .await
+        .map_err(|e| format!("Failed terminate process: {:?}", e))
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -665,9 +705,33 @@ pub fn run() {
                 .map_err(|e| format!("Failed to create tray icon: {}", e))?;
 
             app.manage(states::DataDirPath(app.path().app_data_dir()?));
-            app.manage(Mutex::new(states::AppsRunningStatus {
-                app2child: HashMap::new(),
-            }));
+            app.manage(Arc::new(Mutex::new(states::AppPidMapInner {
+                appid2pid: HashMap::new(),
+                pid2appid: HashMap::new(),
+            })));
+
+            let (proc_mon, proc_mon_rx) = ProcessMonitor::new();
+            let mut proc_mon_rx_for_listener = proc_mon_rx.resubscribe();
+            app.manage(Arc::new(Mutex::new(proc_mon)));
+            app.manage(Arc::new(Mutex::new(proc_mon_rx)));
+
+            // Remove entry from App2Pid state on app termination
+            let app_handle_for_procmon_listener = app.handle().clone();
+            spawn(async move {
+                while let Ok(ev) = proc_mon_rx_for_listener.recv().await {
+                    match ev {
+                        ProcessEvent::Terminated(pid) => {
+                            let app_pid_map_state =
+                                app_handle_for_procmon_listener.state::<states::AppPidMap>();
+                            let mut app_pid_map = app_pid_map_state.lock().await;
+                            let appid = app_pid_map.pid2appid.remove(&pid);
+                            if let Some(appid) = appid {
+                                app_pid_map.appid2pid.remove(&appid);
+                            }
+                        }
+                    }
+                }
+            });
 
             Ok(())
         })
@@ -678,7 +742,9 @@ pub fn run() {
             extract_archive,
             upload_file_as_form_data,
             launch_app,
+            is_app_running,
             wait_for_app_close,
+            terminate_app,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/launcher-rust/src-tauri/src/models.rs
+++ b/apps/launcher-rust/src-tauri/src/models.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct InstalledAppInfo {
+    pub id: String,
+    #[serde(rename = "buildId")]
+    pub build_id: String,
+    #[serde(rename = "installDir")]
+    pub install_dir: PathBuf,
+    #[serde(rename = "storageDir")]
+    pub storage_dir: PathBuf,
+    pub entrypoint: String,
+}

--- a/apps/launcher-rust/src-tauri/src/process_monitor.rs
+++ b/apps/launcher-rust/src-tauri/src/process_monitor.rs
@@ -89,7 +89,7 @@ impl ProcessMonitor {
         let pid = if let Some(v) = child.id() {
             v
         } else {
-            eprintln!("Enable to get child PID");
+            eprintln!("Unable to get child PID");
             return;
         };
 

--- a/apps/launcher-rust/src-tauri/src/process_monitor.rs
+++ b/apps/launcher-rust/src-tauri/src/process_monitor.rs
@@ -95,8 +95,11 @@ impl ProcessMonitor {
 
         tokio::select! {
             res = child.wait() => {
-                if let Err(e) = res {
-                    eprintln!("{}", e);
+                match res {
+                    Ok(_) => {
+                        _ = tx.send(ProcessEvent::Terminated(pid));
+                    }
+                    Err(e) => eprintln!("{}", e),
                 }
             }
 

--- a/apps/launcher-rust/src-tauri/src/process_monitor.rs
+++ b/apps/launcher-rust/src-tauri/src/process_monitor.rs
@@ -1,0 +1,138 @@
+use std::sync::Arc;
+
+use tauri::async_runtime::spawn;
+use tokio::{
+    process::Child,
+    sync::{broadcast, oneshot, Mutex},
+};
+
+pub struct ProcessMonitor {
+    events_channel: broadcast::Sender<ProcessEvent>,
+    processes: Arc<Mutex<Vec<ProcessEntry>>>,
+}
+
+impl ProcessMonitor {
+    pub fn new() -> (Self, broadcast::Receiver<ProcessEvent>) {
+        let (tx, rx) = broadcast::channel(1);
+
+        let processes = Arc::new(Mutex::new(vec![]));
+        let procs_for_cleanup = processes.clone();
+        let mut rx_clone = rx.resubscribe();
+
+        // cleanup listener
+        spawn(async move {
+            while let Ok(ev) = rx_clone.recv().await {
+                match ev {
+                    ProcessEvent::Terminated(pid) => {
+                        _ = Self::remove_process(procs_for_cleanup.clone(), pid).await;
+                    }
+                }
+            }
+        });
+
+        (
+            Self {
+                events_channel: tx,
+                processes,
+            },
+            rx,
+        )
+    }
+
+    /// Add process to monitoring
+    pub async fn add(&mut self, process: Child) {
+        let (m2w_tx, m2w_rx) = oneshot::channel();
+        let pid = process.id().unwrap();
+
+        spawn(Self::child_close_waiter(
+            process,
+            m2w_rx,
+            self.events_channel.clone(),
+        ));
+
+        let mut procs = self.processes.lock().await;
+        procs.push(ProcessEntry { pid, tx: m2w_tx });
+        println!("Monitoring process count: {} (+1)", procs.len());
+    }
+
+    /// Terminate and remove process from monitoring
+    pub async fn terminate(&mut self, pid: u32) -> Result<(), Error> {
+        match Self::remove_process(self.processes.clone(), pid).await {
+            Ok(tx) => {
+                _ = tx.send(Monitor2Waiter::TerminateChild);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn remove_process(
+        procs: Arc<Mutex<Vec<ProcessEntry>>>,
+        pid: u32,
+    ) -> Result<oneshot::Sender<Monitor2Waiter>, Error> {
+        let mut procs = procs.lock().await;
+        let proc = procs.iter().enumerate().find(|(_, it)| it.pid == pid);
+        if let Some((idx, _)) = proc {
+            let entry = procs.swap_remove(idx);
+            println!("Monitoring process count: {} (-1)", procs.len());
+            Ok(entry.tx)
+        } else {
+            Err(Error::ProcessNotFound)
+        }
+    }
+
+    async fn child_close_waiter(
+        mut child: Child,
+        rx: oneshot::Receiver<Monitor2Waiter>,
+        tx: broadcast::Sender<ProcessEvent>,
+    ) {
+        let pid = if let Some(v) = child.id() {
+            v
+        } else {
+            eprintln!("Enable to get child PID");
+            return;
+        };
+
+        tokio::select! {
+            res = child.wait() => {
+                if let Err(e) = res {
+                    eprintln!("{}", e);
+                }
+            }
+
+            msg = rx => {
+                match msg {
+                    Ok(Monitor2Waiter::TerminateChild) => {
+                        if let Err(e) = child.kill().await {
+                            eprintln!("Error during terminating process: {}", e);
+                        } else {
+                            _ = tx.send(ProcessEvent::Terminated(pid));
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Error during receiving channel message: {}", e);
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ProcessEntry {
+    pub pid: u32,
+    pub tx: oneshot::Sender<Monitor2Waiter>,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    ProcessNotFound,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProcessEvent {
+    Terminated(u32),
+}
+
+enum Monitor2Waiter {
+    TerminateChild,
+}

--- a/apps/launcher-rust/src-tauri/src/states.rs
+++ b/apps/launcher-rust/src-tauri/src/states.rs
@@ -1,7 +1,18 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use tokio::sync::{broadcast, Mutex};
+
+use crate::process_monitor::{ProcessEvent, ProcessMonitor};
 
 pub struct DataDirPath(pub PathBuf);
 
-pub struct AppsRunningStatus {
-    pub app2child: HashMap<String, tokio::process::Child>,
+pub struct AppPidMapInner {
+    pub appid2pid: HashMap<String, u32>,
+    pub pid2appid: HashMap<u32, String>,
 }
+
+pub type AppPidMap = Arc<Mutex<AppPidMapInner>>;
+
+pub type ProcessMonitorInstance = Arc<Mutex<ProcessMonitor>>;
+
+pub type ProcessMonitorReceiver = Arc<Mutex<broadcast::Receiver<ProcessEvent>>>;

--- a/apps/launcher-rust/src-tauri/src/states.rs
+++ b/apps/launcher-rust/src-tauri/src/states.rs
@@ -1,0 +1,3 @@
+use std::path::PathBuf;
+
+pub struct DataDirPath(pub PathBuf);

--- a/apps/launcher-rust/src-tauri/src/states.rs
+++ b/apps/launcher-rust/src-tauri/src/states.rs
@@ -1,3 +1,7 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 pub struct DataDirPath(pub PathBuf);
+
+pub struct AppsRunningStatus {
+    pub app2child: HashMap<String, tokio::process::Child>,
+}

--- a/apps/launcher-rust/src/components/LibraryAppController.vue
+++ b/apps/launcher-rust/src/components/LibraryAppController.vue
@@ -318,9 +318,11 @@ const launch = async () => {
     throw new Error('State error. Should not call if config is not loaded')
   }
 
-  const entrypointPath = await path.join(config.value.installDir, config.value.entrypoint)
-
-  await openPath(entrypointPath)
+  try {
+    await invoke('launch_app', { appId: config.value.id })
+  } catch (e) {
+    actionError.value = `failed launch application (${e})`
+  }
 }
 
 const close = async () => {}

--- a/apps/launcher-rust/src/components/LibraryAppController.vue
+++ b/apps/launcher-rust/src/components/LibraryAppController.vue
@@ -128,6 +128,12 @@ const calculateState = async () => {
 
   saveAppConfig(config.value)
   state.value = 'ready'
+
+  if (await invoke('is_app_running', { appId: config.value.id })) {
+    state.value = 'running'
+    await invoke('wait_for_app_close', { appId: config.value.id })
+    state.value = 'ready'
+  }
 }
 
 onMounted(calculateState)
@@ -330,7 +336,9 @@ const launch = async () => {
   state.value = 'ready'
 }
 
-const close = async () => {}
+const close = async () => {
+  await invoke('terminate_app', { appId: config.value?.id })
+}
 
 const openLocalFiles = async () => {
   if (config.value == undefined) {

--- a/apps/launcher-rust/src/components/LibraryAppController.vue
+++ b/apps/launcher-rust/src/components/LibraryAppController.vue
@@ -322,7 +322,12 @@ const launch = async () => {
     await invoke('launch_app', { appId: config.value.id })
   } catch (e) {
     actionError.value = `failed launch application (${e})`
+    return
   }
+
+  state.value = 'running'
+  await invoke('wait_for_app_close', { appId: config.value.id })
+  state.value = 'ready'
 }
 
 const close = async () => {}


### PR DESCRIPTION
Простое отслеживание запущенного приложения.
В дальнейшем можно сделать отслеживание всей ветки порождённого процесса, не только запущенного процесса, т.к. некоторые приложения могут иметь entry point который работает как легковесный трамплин запуская другой бинарник (некоторые кастомные игровые движки имеют для каждого render api отдельный бинарь).

https://github.com/user-attachments/assets/9a00143d-d82d-4ba7-9b12-45594a6ee9ec

